### PR TITLE
chore(tweet): recurring tweet about slack link

### DIFF
--- a/tweets/recurring-slack-link/2024-07-27.tweet
+++ b/tweets/recurring-slack-link/2024-07-27.tweet
@@ -1,0 +1,7 @@
+✨ Did you know #AsyncAPI is on Slack? ✨ 
+
+Join our Slack workspace to chat with anyone from our Open-Source community! 
+
+🔗 asyncapi.com/slack-invite 
+
+Ask for help and help others too. 💪🏿💪🏽🦾


### PR DESCRIPTION
This is a tweet that we want to share regularly to make sure all AsyncAPI followers know about our slack workspace